### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 # Travel Planner MCP Server (@gongrzhe/server-travelplanner-mcp)
+[![smithery badge](https://smithery.ai/badge/@GongRzhe/TRAVEL-PLANNER-MCP-Server)](https://smithery.ai/server/@GongRzhe/TRAVEL-PLANNER-MCP-Server)
 
 A Travel Planner Model Context Protocol (MCP) server implementation for interacting with Google Maps and travel planning services. This server enables LLMs to perform travel-related tasks such as location search, place details lookup, and travel time calculations.
 
 ## Installation & Usage
+### Installing via Smithery
 
+To install Travel Planner for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@GongRzhe/TRAVEL-PLANNER-MCP-Server):
+
+```bash
+npx -y @smithery/cli install @GongRzhe/TRAVEL-PLANNER-MCP-Server --client claude
+```
+
+### Installing Manually
 ```bash
 # Using npx (recommended)
 npx @gongrzhe/server-travelplanner-mcp

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,17 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - googleMapsApiKey
+    properties:
+      googleMapsApiKey:
+        type: string
+        description: The API key for accessing Google Maps services.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({ command: 'node', args: ['dist/index.js'], env: { GOOGLE_MAPS_API_KEY: config.googleMapsApiKey } })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@GongRzhe/TRAVEL-PLANNER-MCP-Server?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂