### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 A Travel Planner Model Context Protocol (MCP) server implementation for interacting with Google Maps and travel planning services. This server enables LLMs to perform travel-related tasks such as location search, place details lookup, and travel time calculations.
 
+<a href="https://glama.ai/mcp/servers/y3u6yjiiq1">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/y3u6yjiiq1/badge" alt="Travel Planner Server MCP server" />
+</a>
+
 ## Installation & Usage
 ### Installing via Smithery
 
@@ -120,4 +124,4 @@ Alternatively, you can use the node command directly if you have the package ins
 
 ## License
 
-This MCP server is licensed under the MIT License. For more details, please see the LICENSE file in the project repository. 
+This MCP server is licensed under the MIT License. For more details, please see the LICENSE file in the project repository.


### PR DESCRIPTION
This PR adds a badge for the [Travel Planner MCP Server](https://glama.ai/mcp/servers/y3u6yjiiq1) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/y3u6yjiiq1">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/y3u6yjiiq1/badge" alt="Travel Planner Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.